### PR TITLE
Feature/add-user-scope-check

### DIFF
--- a/config/auth.js
+++ b/config/auth.js
@@ -28,7 +28,10 @@ export default {
                 request.route.method.toUpperCase() ===
                     route.method.toUpperCase()
             ) {
-                isAllowed = includes(route.scopes, client.scope.scope);
+                isAllowed = route.customValidator
+                    ? route.customValidator(credentials, request) &&
+                      includes(route.scopes, client.scope.scope)
+                    : includes(route.scopes, client.scope.scope);
             }
         });
 

--- a/config/auth.js
+++ b/config/auth.js
@@ -1,10 +1,9 @@
 import isNil from 'lodash/isNil';
-import includes from 'lodash/includes';
 import { updateAccessToken, findAccessToken } from 'daos/oauthAccessTokensDao';
-import { getMetaDataByOAuthClientId } from 'daos/oauthClientsDao';
 import { unauthorized } from 'utils/responseInterceptors';
 import { paths } from 'config/paths';
 import { SLIDING_WINDOW } from 'utils/constants';
+import { validateScopeForRoute } from 'utils';
 
 export default {
     allowQueryToken: false,
@@ -15,33 +14,15 @@ export default {
             throw unauthorized(`Access denied. Unauthorized user.`);
         }
         const artifacts = credentials.metadata;
-
-        const client = await getMetaDataByOAuthClientId(
-            credentials.oauthClientId
+        const isValid = await validateScopeForRoute(
+            paths,
+            request,
+            credentials
         );
-        let isAllowed = true;
-        async function validateScope() {
-            let route;
-            for (let index = 0; index < paths.length; index++) {
-                route = paths[index];
-                if (
-                    request.route.path === route.path &&
-                    request.route.method.toUpperCase() ===
-                        route.method.toUpperCase()
-                ) {
-                    isAllowed = route.customValidator
-                        ? (await route.customValidator(credentials, request)) &&
-                          includes(route.scopes, client.scope.scope)
-                        : includes(route.scopes, client.scope.scope);
-                }
-            }
-            return isAllowed;
-        }
-        isAllowed = await validateScope();
         updateAccessToken(token, SLIDING_WINDOW);
 
         return {
-            isValid: isAllowed,
+            isValid,
             credentials,
             artifacts
         };

--- a/config/paths.js
+++ b/config/paths.js
@@ -1,4 +1,7 @@
+import get from 'lodash/get';
 import { SCOPE_TYPE } from 'utils/constants';
+import { hasScopeOverUser } from 'utils/index';
+
 export const paths = [
     {
         path: '/me',
@@ -72,6 +75,11 @@ export const paths = [
             SCOPE_TYPE.ADMIN,
             SCOPE_TYPE.USER
         ],
-        method: 'GET'
+        method: 'GET',
+        customValidator: async (credentials, request) =>
+            await hasScopeOverUser(
+                get(credentials, 'oauthClientId'),
+                get(request, 'params.userId')
+            )
     }
 ];

--- a/config/paths.js
+++ b/config/paths.js
@@ -69,7 +69,8 @@ export const paths = [
         scopes: [
             SCOPE_TYPE.INTERNAL_SERVICE,
             SCOPE_TYPE.SUPER_ADMIN,
-            SCOPE_TYPE.ADMIN
+            SCOPE_TYPE.ADMIN,
+            SCOPE_TYPE.USER
         ],
         method: 'GET'
     }

--- a/lib/daos/userDao.js
+++ b/lib/daos/userDao.js
@@ -1,6 +1,12 @@
-import { users, oauth_clients as oauthClients } from 'models';
+import { users } from 'models';
 
-const attributes = ['id', 'first_name', 'last_name', 'email'];
+const attributes = [
+    'id',
+    'first_name',
+    'last_name',
+    'email',
+    'oauth_client_id'
+];
 
 export const findOneUser = async userId =>
     users.findOne({
@@ -21,23 +27,4 @@ export const findAllUser = async (page, limit) => {
         limit
     });
     return { allUsers, totalCount };
-};
-
-export const findUserById = async id => {
-    try {
-        users.hasOne(oauthClients, { foreignKey: 'id' });
-        return users.findOne({
-            attributes: [...attributes, 'oauth_client_id'],
-            where: {
-                id
-            },
-            include: [
-                {
-                    model: oauthClients
-                }
-            ]
-        });
-    } catch {
-        return null;
-    }
 };

--- a/lib/daos/userDao.js
+++ b/lib/daos/userDao.js
@@ -1,8 +1,10 @@
-import { users } from 'models';
+import { users, oauth_clients as oauthClients } from 'models';
 
-export const findOneUser = userId =>
+const attributes = ['id', 'first_name', 'last_name', 'email'];
+
+export const findOneUser = async userId =>
     users.findOne({
-        attributes: ['id', 'first_name', 'last_name', 'email'],
+        attributes,
         where: {
             id: userId
         },
@@ -13,10 +15,29 @@ export const findAllUser = async (page, limit) => {
     const where = {};
     const totalCount = await users.count({ where });
     const allUsers = await users.findAll({
-        attributes: ['id', 'first_name', 'last_name', 'email'],
+        attributes,
         where,
         offset: (page - 1) * limit,
         limit
     });
     return { allUsers, totalCount };
+};
+
+export const findUserById = async id => {
+    try {
+        users.hasOne(oauthClients, { foreignKey: 'id' });
+        return users.findOne({
+            attributes: [...attributes, 'oauth_client_id'],
+            where: {
+                id
+            },
+            include: [
+                {
+                    model: oauthClients
+                }
+            ]
+        });
+    } catch {
+        return null;
+    }
 };

--- a/tests/libs/daos/userDao.test.js
+++ b/tests/libs/daos/userDao.test.js
@@ -3,7 +3,13 @@ import { mockData } from 'utils/mockData';
 
 describe('user daos', () => {
     const { MOCK_USER: mockUser } = mockData;
-    const attributes = ['id', 'first_name', 'last_name', 'email'];
+    const attributes = [
+        'id',
+        'first_name',
+        'last_name',
+        'email',
+        'oauth_client_id'
+    ];
 
     describe('findOneUser', () => {
         it('should find a user by ID', async () => {

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -29,3 +29,5 @@ export const SUPER_SCOPES = [
 ];
 
 export const GET_USER_PATH = '/users/{userId}';
+
+export const USER_ID = 'USER_ID';

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -22,3 +22,10 @@ export const ADMINS = [SCOPE_TYPE.SUPER_ADMIN, SCOPE_TYPE.ADMIN];
 export const SLIDING_WINDOW = 1 * 24 * 60 * 60; // days * hours * minutes * seconds *
 export const INVALID_CLIENT_CREDENTIALS = 'Invalid client credentials';
 export const OAUTH_CLIENT_ID = 'OAUTH_CLIENT_ID';
+
+export const SUPER_SCOPES = [
+    SCOPE_TYPE.SUPER_ADMIN,
+    SCOPE_TYPE.INTERNAL_SERVICE
+];
+
+export const GET_USER_PATH = '/users/{userId}';

--- a/utils/index.js
+++ b/utils/index.js
@@ -12,7 +12,7 @@ import {
 } from 'utils/constants';
 import { getMetaDataByOAuthClientId } from 'daos/oauthClientsDao';
 import { TIMESTAMP } from './constants';
-import { findUserById } from 'daos/userDao';
+import { findOneUser } from 'daos/userDao';
 
 export const getEnv = () => {
     switch (process.env.NODE_ENV) {
@@ -117,7 +117,7 @@ export async function hasScopeOverUser(oauthClientId, userId) {
             )
         );
     } else if (scope === SCOPE_TYPE.USER) {
-        const result = await findUserById(userId);
+        const result = await findOneUser(userId);
         console.log({ result }, result.oauth_client_id === oauthClientId);
         if (!isNil(result)) {
             return result.oauth_client_id === oauthClientId;

--- a/utils/index.js
+++ b/utils/index.js
@@ -8,7 +8,8 @@ import {
     ADMINS,
     SCOPE_TYPE,
     OAUTH_CLIENT_ID,
-    SUPER_SCOPES
+    SUPER_SCOPES,
+    USER_ID
 } from 'utils/constants';
 import { getMetaDataByOAuthClientId } from 'daos/oauthClientsDao';
 import { TIMESTAMP } from './constants';
@@ -103,7 +104,6 @@ export const getScope = oauthClientId =>
 
 export async function hasScopeOverUser(oauthClientId, userId) {
     const scope = await getScope(oauthClientId);
-    console.log({ scope });
     if (includes(SUPER_SCOPES, scope)) {
         return true;
     } else if (scope === SCOPE_TYPE.ADMIN) {
@@ -112,13 +112,12 @@ export async function hasScopeOverUser(oauthClientId, userId) {
         return !isEmpty(
             resources.filter(
                 resource =>
-                    resource.resource_type === 'USER_ID' &&
+                    resource.resource_type === USER_ID &&
                     resource.resource_id === userId
             )
         );
     } else if (scope === SCOPE_TYPE.USER) {
         const result = await findOneUser(userId);
-        console.log({ result }, result.oauth_client_id === oauthClientId);
         if (!isNil(result)) {
             return result.oauth_client_id === oauthClientId;
         }

--- a/utils/mockData.js
+++ b/utils/mockData.js
@@ -37,6 +37,20 @@ export const mockData = {
         grantType: GRANT_TYPE.CLIENT_CREDENTIALS,
         ...mockMetadata()
     },
+    MOCK_OAUTH_CLIENT_TWO: {
+        id: 2,
+        clientId: 'TEST_CLIENT_ID_2',
+        clientSecret: 'TEST_CLIENT_SECRET',
+        grantType: GRANT_TYPE.CLIENT_CREDENTIALS,
+        ...mockMetadata(SCOPE_TYPE.USER)
+    },
+    MOCK_OAUTH_CLIENT_SUPER_USER: {
+        id: 2,
+        clientId: 'TEST_CLIENT_ID_2',
+        clientSecret: 'TEST_CLIENT_SECRET',
+        grantType: GRANT_TYPE.CLIENT_CREDENTIALS,
+        ...mockMetadata(SCOPE_TYPE.SUPER_ADMIN)
+    },
     MOCK_OAUTH_CLIENT_RESOURCES: [
         {
             id: 1,


### PR DESCRIPTION
### Description

Added a scope check in the auth middleware for `/users/{userId}` path. The scope check makes sure that -- 
1. A `SUPER_ADMIN` client can access any user data
2. An `INTERNAL_SERVICE` client can access any user data
3. An `ADMIN` client can only access userId that are saved in `resources` as `resourceId` and `resourceType` should be set as `USER_ID`.
4. A `USER` client can only access there own data.

### Gif
![pr-4-users-scope-check-v1](https://user-images.githubusercontent.com/62387714/90763410-4712a500-e304-11ea-9a35-ce7b675ccad9.gif)
