### PR TITLE
feature/add-client-route-tests-dao-tests

### DIFF
--- a/tests/libs/daos/oauthAccessTokensDao.test.js
+++ b/tests/libs/daos/oauthAccessTokensDao.test.js
@@ -53,6 +53,16 @@ describe('oauthAccessTokenDao', () => {
                 })
             );
         });
+        it('should catch an error if no metadata is found', async () => {
+            await resetAndMockDB(db => {
+                db.oauth_clients.findOne = () =>
+                    new Promise(resolve => resolve(null));
+            });
+            const { createAccessToken } = require('daos/oauthAccessTokensDao');
+            expect(
+                createAccessToken(authClientsMockData.id, ttl)
+            ).rejects.toThrow();
+        });
     });
 
     describe('findAccessToken', () => {
@@ -65,6 +75,15 @@ describe('oauthAccessTokenDao', () => {
             'oauthClientId'
         ];
         const accessToken = 1;
+
+        it('should return a null token if no tokens are found', async () => {
+            await resetAndMockDB(db => {
+                db.oauth_access_tokens.findOne = async () => null;
+            });
+            const { findAccessToken } = require('daos/oauthAccessTokensDao');
+            expect(await findAccessToken(accessToken)).toEqual(null);
+        });
+
         it('should call findOne in the oauthAccessTokens table with the correct parameters ', async () => {
             await resetAndMockDB(db => {
                 spy = jest.spyOn(db.oauth_access_tokens, 'findOne');

--- a/tests/libs/daos/oauthClientResourcesDao.test.js
+++ b/tests/libs/daos/oauthClientResourcesDao.test.js
@@ -130,6 +130,17 @@ describe('oauthClientResources dao', () => {
             await resetAndMockDB();
             await expect(updateResource(resource, userToken)).rejects.toThrow();
         });
+
+        it('should catch an error if findResourceWithOauthClientId fails', async () => {
+            await resetAndMockDB(db => {
+                db.oauth_client_resources.findOne = async () => {
+                    throw new Error('resource not found');
+                };
+            });
+            const { updateResource } = require('daos/oauthClientResourcesDao');
+
+            expect(updateResource(resource, superAdminToken)).rejects.toThrow();
+        });
     });
 
     describe('createOauthResources', () => {

--- a/tests/routes/oauth2/clients.test.js
+++ b/tests/routes/oauth2/clients.test.js
@@ -1,0 +1,74 @@
+/* global server */
+const payload = {
+    scope: 'ADMIN',
+    resources: [
+        {
+            resource_type: 'USER_ID',
+            resource_id: '2'
+        }
+    ],
+    client_id: 'TEST_CLIENT_ID_7',
+    client_secret: 'TEST_CLIENT_SECRET',
+    grant_type: 'CLIENT_CREDENTIALS'
+};
+
+const responseBody = {
+    oauth_client: {
+        client_id: 'TEST_CLIENT_ID_7',
+        grant_type: 'CLIENT_CREDENTIALS'
+    },
+    resources: [
+        {
+            id: 1,
+            oauth_client_id: 1,
+            resource_type: 'USER_ID',
+            resource_id: '2'
+        }
+    ],
+    scopes: {
+        id: 1,
+        scope: 'ADMIN',
+        oauth_client_id: 1
+    }
+};
+
+describe('/oauth2/clients route tests', () => {
+    it('should create a client with the provided credientials and resources', async () => {
+        const res = await server.inject({
+            method: 'POST',
+            url: '/oauth2/clients',
+            payload
+        });
+        expect(res.statusCode).toEqual(200);
+        expect(res.payload).toEqual(
+            expect.stringContaining(
+                JSON.stringify(responseBody.oauth_client.client_id)
+            )
+        );
+        expect(res.payload).toEqual(
+            expect.stringContaining(
+                JSON.stringify(responseBody.oauth_client.grant_type)
+            )
+        );
+        expect(res.payload).toEqual(
+            expect.stringContaining(
+                JSON.stringify(responseBody.resources[0].resource_id)
+            )
+        );
+        expect(res.payload).toEqual(
+            expect.stringContaining(
+                JSON.stringify(responseBody.resources[0].resource_type)
+            )
+        );
+    });
+    it('should validate the parameters correctly', async () => {
+        payload.scope = 1;
+        const res = await server.inject({
+            method: 'POST',
+            url: '/oauth2/clients',
+            payload
+        });
+        expect(res.statusCode).toEqual(400);
+        expect(res.result.error).toEqual('Bad Request');
+    });
+});

--- a/tests/routes/oauth2/clients.test.js
+++ b/tests/routes/oauth2/clients.test.js
@@ -12,26 +12,6 @@ const payload = {
     grant_type: 'CLIENT_CREDENTIALS'
 };
 
-const responseBody = {
-    oauth_client: {
-        client_id: 'TEST_CLIENT_ID_7',
-        grant_type: 'CLIENT_CREDENTIALS'
-    },
-    resources: [
-        {
-            id: 1,
-            oauth_client_id: 1,
-            resource_type: 'USER_ID',
-            resource_id: '2'
-        }
-    ],
-    scopes: {
-        id: 1,
-        scope: 'ADMIN',
-        oauth_client_id: 1
-    }
-};
-
 describe('/oauth2/clients route tests', () => {
     it('should create a client with the provided credientials and resources', async () => {
         const res = await server.inject({
@@ -40,25 +20,15 @@ describe('/oauth2/clients route tests', () => {
             payload
         });
         expect(res.statusCode).toEqual(200);
-        expect(res.payload).toEqual(
-            expect.stringContaining(
-                JSON.stringify(responseBody.oauth_client.client_id)
-            )
+        const { result } = res;
+        expect(result.oauth_client.client_id).toEqual(payload.client_id);
+        expect(result.oauth_client.grant_type).toEqual(payload.grant_type);
+        expect(result.resources[0].resource_id).toEqual(
+            payload.resources[0].resource_id
         );
-        expect(res.payload).toEqual(
-            expect.stringContaining(
-                JSON.stringify(responseBody.oauth_client.grant_type)
-            )
-        );
-        expect(res.payload).toEqual(
-            expect.stringContaining(
-                JSON.stringify(responseBody.resources[0].resource_id)
-            )
-        );
-        expect(res.payload).toEqual(
-            expect.stringContaining(
-                JSON.stringify(responseBody.resources[0].resource_type)
-            )
+
+        expect(result.resources[0].resource_type).toEqual(
+            payload.resources[0].resource_type
         );
     });
     it('should validate the parameters correctly', async () => {


### PR DESCRIPTION
### Description 

Added more tests for daos to improve coverage.
Added oauth2/client route tests

<img width="659" alt="Screenshot 2020-08-21 at 1 02 50 AM" src="https://user-images.githubusercontent.com/62387714/90816561-181f2200-e34a-11ea-81ce-68eff1c27b2a.png">

### Gif
![pr-5-daotests-create-route-tests-v1](https://user-images.githubusercontent.com/62387714/90816507-0473bb80-e34a-11ea-84aa-195dda004445.gif)
