### PR TITLE
feature/add-util-tests

### DIFF
--- a/config/auth.js
+++ b/config/auth.js
@@ -14,11 +14,11 @@ export default {
             throw unauthorized(`Access denied. Unauthorized user.`);
         }
         const artifacts = credentials.metadata;
-        const isValid = await validateScopeForRoute(
+        const isValid = await validateScopeForRoute({
             paths,
             request,
             credentials
-        );
+        });
         updateAccessToken(token, SLIDING_WINDOW);
 
         return {

--- a/config/paths.js
+++ b/config/paths.js
@@ -1,4 +1,3 @@
-import get from 'lodash/get';
 import { SCOPE_TYPE } from 'utils/constants';
 import { hasScopeOverUser } from 'utils/index';
 
@@ -15,7 +14,7 @@ export const paths = [
     },
     {
         path: '/oauth2/resources/{resourceId}',
-        scopes: [SCOPE_TYPE.SUPER_ADMIN, SCOPE_TYPE.ADMIN.lue],
+        scopes: [SCOPE_TYPE.SUPER_ADMIN, SCOPE_TYPE.ADMIN],
         method: 'PATCH'
     },
     {
@@ -56,7 +55,7 @@ export const paths = [
             SCOPE_TYPE.ADMIN,
             SCOPE_TYPE.USER
         ],
-        method: 'POST'
+        method: 'GET'
     },
     {
         path: '/users',
@@ -76,10 +75,6 @@ export const paths = [
             SCOPE_TYPE.USER
         ],
         method: 'GET',
-        customValidator: async (credentials, request) =>
-            await hasScopeOverUser(
-                get(credentials, 'oauthClientId'),
-                get(request, 'params.userId')
-            )
+        customValidator: async payload => await hasScopeOverUser(payload)
     }
 ];

--- a/tests/libs/daos/oauthAccessTokensDao.test.js
+++ b/tests/libs/daos/oauthAccessTokensDao.test.js
@@ -5,6 +5,7 @@ import server from 'config/server';
 describe('oauthAccessTokenDao', () => {
     const { MOCK_OAUTH_CLIENTS: authClientsMockData } = mockData;
     const metaData = mockMetadata();
+    const oauthClientId = authClientsMockData().id;
 
     describe('createAccessToken', () => {
         let spy;
@@ -19,12 +20,12 @@ describe('oauthAccessTokenDao', () => {
                 spy = jest.spyOn(db.oauth_access_tokens, 'create');
             });
             const { createAccessToken } = require('daos/oauthAccessTokensDao');
-            await createAccessToken(authClientsMockData.id, ttl);
+            await createAccessToken(oauthClientId, ttl);
 
             expect(spy).toHaveBeenCalledWith(
                 expect.objectContaining({
                     accessToken: expect.any(String),
-                    oauthClientId: authClientsMockData.id,
+                    oauthClientId: oauthClientId,
                     expiresIn: ttl,
                     expiresOn: expect.any(String),
                     tokenType: BEARER,
@@ -46,10 +47,10 @@ describe('oauthAccessTokenDao', () => {
                 spy = jest.spyOn(db.oauth_clients, 'findOne');
             });
             const { createAccessToken } = require('daos/oauthAccessTokensDao');
-            await createAccessToken(authClientsMockData.id, ttl);
+            await createAccessToken(oauthClientId, ttl);
             expect(spy).toBeCalledWith(
                 expect.objectContaining({
-                    where: { id: authClientsMockData.id }
+                    where: { id: oauthClientId }
                 })
             );
         });
@@ -59,9 +60,7 @@ describe('oauthAccessTokenDao', () => {
                     new Promise(resolve => resolve(null));
             });
             const { createAccessToken } = require('daos/oauthAccessTokensDao');
-            expect(
-                createAccessToken(authClientsMockData.id, ttl)
-            ).rejects.toThrow();
+            expect(createAccessToken(oauthClientId, ttl)).rejects.toThrow();
         });
     });
 

--- a/tests/libs/daos/oauthClientResourcesDao.test.js
+++ b/tests/libs/daos/oauthClientResourcesDao.test.js
@@ -14,7 +14,7 @@ describe('oauthClientResources dao', () => {
     ];
     let spy;
     const id = 1;
-    const oauthClientId = authClientsMockData.clientId;
+    const oauthClientId = authClientsMockData().clientId;
     const token = { oauthClientId };
     const superAdminToken = createMockTokenWithScope(SCOPE_TYPE.SUPER_ADMIN);
     const userToken = createMockTokenWithScope(SCOPE_TYPE.USER);

--- a/tests/libs/daos/oauthClientsDao.test.js
+++ b/tests/libs/daos/oauthClientsDao.test.js
@@ -5,8 +5,8 @@ import { SCOPE_TYPE, GRANT_TYPE } from 'utils/constants';
 describe('oauthClients Dao tests', () => {
     let spy;
     const grantType = GRANT_TYPE.CLIENT_CREDENTIALS;
-    const oauthClient = mockData.MOCK_OAUTH_CLIENTS;
-    const clientId = mockData.MOCK_OAUTH_CLIENTS.clientId;
+    const oauthClient = mockData.MOCK_OAUTH_CLIENTS();
+    const clientId = mockData.MOCK_OAUTH_CLIENTS().clientId;
     let clientSecret = 'TEST';
     const resources = mockData.MOCK_OAUTH_CLIENT_RESOURCES;
     const scope = SCOPE_TYPE.ADMIN;

--- a/tests/utils/index.test.js
+++ b/tests/utils/index.test.js
@@ -1,0 +1,333 @@
+import moment from 'moment';
+import get from 'lodash/get';
+import {
+    TIMESTAMP,
+    SCOPE_TYPE,
+    USER_ID,
+    OAUTH_CLIENT_ID
+} from 'utils/constants';
+import {
+    createMockTokenWithScope,
+    mockData,
+    mockMetadata
+} from 'utils/mockData';
+import { resetAndMockDB } from 'utils/testUtils';
+
+describe('util tests', () => {
+    const adminToken = createMockTokenWithScope(SCOPE_TYPE.ADMIN);
+    const userToken = createMockTokenWithScope(SCOPE_TYPE.USER);
+    const superAdminToken = createMockTokenWithScope(SCOPE_TYPE.SUPER_ADMIN);
+    const internalServiceToken = createMockTokenWithScope(
+        SCOPE_TYPE.INTERNAL_SERVICE
+    );
+    const {
+        MOCK_OAUTH_CLIENTS: adminClient,
+        MOCK_OAUTH_CLIENT_SUPER_USER: superClient,
+        MOCK_OAUTH_CLIENT_TWO: userClient
+    } = mockData;
+
+    describe('getEnv', () => {
+        it('should return the environment that is passed as a string', () => {
+            const environments = {
+                production: 'production',
+                qa: 'qa',
+                staging: 'staging',
+                development: 'development'
+            };
+            const { getEnv } = require('utils');
+            process.env.NODE_ENV = environments.production;
+            const productionEnv = getEnv();
+            expect(productionEnv).toEqual(environments.production);
+            process.env.NODE_ENV = environments.qa;
+            const qaEnv = getEnv();
+            expect(qaEnv).toEqual(environments.qa);
+            process.env.NODE_ENV = environments.staging;
+            const stagingEnv = getEnv();
+            expect(stagingEnv).toEqual(environments.staging);
+            process.env.NODE_ENV = 'TEST';
+            const defaultEnv = getEnv();
+            expect(defaultEnv).toEqual(environments.development);
+        });
+    });
+
+    describe('formatWithTimestamp', () => {
+        it('should format the provided moment', () => {
+            const now = moment();
+            const nowFormatted = moment().format(TIMESTAMP);
+            const { formatWithTimestamp } = require('utils');
+            const nowFormattedTest = formatWithTimestamp(now);
+            expect(nowFormatted).toEqual(nowFormattedTest);
+        });
+    });
+
+    describe('strippedUUID', () => {
+        it('should return a uuid with no `-` ', () => {
+            const { strippedUUID } = require('utils');
+            const uuId = strippedUUID();
+            expect(uuId).toEqual(expect.not.stringMatching(/-/g));
+        });
+    });
+
+    describe('isAdmin', () => {
+        it('should check if the provided token has a scope status of ADMINS ', async () => {
+            const { isAdmin } = require('utils');
+            let adminCheckResult = await isAdmin(adminToken);
+            expect(adminCheckResult).toBeTruthy();
+            adminCheckResult = await isAdmin(userToken);
+            expect(adminCheckResult).toBeFalsy();
+            adminCheckResult = await isAdmin(superAdminToken);
+            expect(adminCheckResult).toBeTruthy();
+            adminCheckResult = await isAdmin(internalServiceToken);
+            expect(adminCheckResult).toBeTruthy();
+        });
+    });
+
+    describe('isScopeHigher', () => {
+        it('should check if the token has higher scope ', async () => {
+            const { isScopeHigher } = require('utils');
+
+            // user token
+            let isScopeHigherCheck = await isScopeHigher(
+                userToken,
+                SCOPE_TYPE.USER
+            );
+            expect(isScopeHigherCheck).toBeFalsy();
+            isScopeHigherCheck = await isScopeHigher(
+                userToken,
+                SCOPE_TYPE.ADMIN
+            );
+            expect(isScopeHigherCheck).toBeFalsy();
+            isScopeHigherCheck = await isScopeHigher(
+                userToken,
+                SCOPE_TYPE.SUPER_ADMIN
+            );
+            expect(isScopeHigherCheck).toBeFalsy();
+
+            // admin token
+            isScopeHigherCheck = await isScopeHigher(
+                adminToken,
+                SCOPE_TYPE.USER
+            );
+            expect(isScopeHigherCheck).toBeTruthy();
+            isScopeHigherCheck = await isScopeHigher(
+                adminToken,
+                SCOPE_TYPE.ADMIN
+            );
+            expect(isScopeHigherCheck).toBeFalsy();
+            isScopeHigherCheck = await isScopeHigher(
+                adminToken,
+                SCOPE_TYPE.SUPER_ADMIN
+            );
+            expect(isScopeHigherCheck).toBeFalsy();
+
+            // super admin token
+            const allScopes = Object.keys(SCOPE_TYPE);
+
+            await Promise.all(
+                allScopes.map(async scope => {
+                    isScopeHigherCheck = await isScopeHigher(
+                        superAdminToken,
+                        SCOPE_TYPE[scope]
+                    );
+                    if (scope !== SCOPE_TYPE.INTERNAL_SERVICE)
+                        expect(isScopeHigherCheck).toBeTruthy();
+                })
+            );
+
+            isScopeHigherCheck = await isScopeHigher(superAdminToken, null);
+            expect(isScopeHigherCheck).toBeFalsy();
+        });
+    });
+    describe('getScopeFromToken', () => {
+        it('should extract the scope from the metadata of a token', async () => {
+            const { getScopeFromToken } = require('utils');
+            let extractedScope = await getScopeFromToken(userToken);
+            expect(extractedScope).toEqual(SCOPE_TYPE.USER);
+            extractedScope = await getScopeFromToken(adminToken);
+            expect(extractedScope).toEqual(SCOPE_TYPE.ADMIN);
+        });
+    });
+    describe('hasPowerOver', () => {
+        it('should check if the token has power over a oauthClient', () => {
+            const { hasPowerOver } = require('utils');
+            // super admin token
+            let hasPowerOverResult = hasPowerOver(
+                superAdminToken,
+                superClient.id,
+                SCOPE_TYPE.SUPER_ADMIN
+            );
+            expect(hasPowerOverResult).toBeTruthy();
+            hasPowerOverResult = hasPowerOver(
+                superAdminToken,
+                adminClient().id,
+                SCOPE_TYPE.ADMIN
+            );
+            expect(hasPowerOverResult).toBeTruthy();
+            hasPowerOverResult = hasPowerOver(
+                superAdminToken,
+                userClient.id,
+                SCOPE_TYPE.USER
+            );
+            expect(hasPowerOverResult).toBeTruthy();
+
+            // admin token
+            hasPowerOverResult = hasPowerOver(
+                adminToken,
+                superClient.id,
+                SCOPE_TYPE.SUPER_ADMIN
+            );
+            expect(hasPowerOverResult).toBeFalsy();
+            hasPowerOverResult = hasPowerOver(
+                adminToken,
+                adminClient().id,
+                SCOPE_TYPE.ADMIN
+            );
+            expect(hasPowerOverResult).toBeFalsy();
+            hasPowerOverResult = hasPowerOver(
+                adminToken,
+                userClient.id,
+                SCOPE_TYPE.USER
+            );
+            expect(hasPowerOverResult).toBeTruthy();
+
+            // user token
+            hasPowerOverResult = hasPowerOver(
+                userToken,
+                superClient.id,
+                SCOPE_TYPE.SUPER_ADMIN
+            );
+            expect(hasPowerOverResult).toBeFalsy();
+            hasPowerOverResult = hasPowerOver(
+                userToken,
+                adminClient().id,
+                SCOPE_TYPE.ADMIN
+            );
+            expect(hasPowerOverResult).toBeFalsy();
+            hasPowerOverResult = hasPowerOver(
+                userToken,
+                userClient.id,
+                SCOPE_TYPE.USER
+            );
+            expect(hasPowerOverResult).toBeFalsy();
+        });
+    });
+    describe('getScope', () => {
+        it('should get the scope from oauthClientId for a User', async () => {
+            const SequelizeMock = require('sequelize-mock');
+            const DBConnectionMock = new SequelizeMock();
+            const userClientMock = DBConnectionMock.define(
+                'oauth_clients',
+                userClient
+            );
+            await resetAndMockDB(db => (db.oauth_clients = userClientMock));
+            const { getScope } = require('utils');
+            const scope = await getScope(userClient.id);
+            expect(scope).toEqual(SCOPE_TYPE.USER);
+        });
+        it('should get the scope from oauthClientId for an Admin', async () => {
+            const SequelizeMock = require('sequelize-mock');
+            const DBConnectionMock = new SequelizeMock();
+            const adminClientMock = DBConnectionMock.define(
+                'oauth_clients',
+                adminClient()
+            );
+            await resetAndMockDB(db => (db.oauth_clients = adminClientMock));
+            const { getScope } = require('utils');
+            const scope = await getScope(adminClient().id);
+            expect(scope).toEqual(SCOPE_TYPE.ADMIN);
+        });
+        it('should get the scope from oauthClientId for a Super Admin', async () => {
+            const SequelizeMock = require('sequelize-mock');
+            const DBConnectionMock = new SequelizeMock();
+            const superadminClientMock = DBConnectionMock.define(
+                'oauth_clients',
+                superClient
+            );
+            await resetAndMockDB(
+                db => (db.oauth_clients = superadminClientMock)
+            );
+            const { getScope } = require('utils');
+            const scope = await getScope(superClient.id);
+            expect(scope).toEqual(SCOPE_TYPE.SUPER_ADMIN);
+        });
+    });
+
+    describe('hasScopeOverUser', () => {
+        it('should check if the Admin has scope over a user', async () => {
+            const SequelizeMock = require('sequelize-mock');
+            const DBConnectionMock = new SequelizeMock();
+            const adminWithUserIdResource = {
+                ...adminClient(),
+                ...mockMetadata(SCOPE_TYPE.ADMIN, USER_ID)
+            };
+            const adminClientMock = DBConnectionMock.define(
+                'oauth_clients',
+                adminWithUserIdResource
+            );
+            await resetAndMockDB(db => (db.oauth_clients = adminClientMock));
+            let userId = 1;
+            const { hasScopeOverUser } = require('utils');
+            const oauthClientId = adminClient().id;
+            let scopeCheck = await hasScopeOverUser({
+                oauthClientId,
+                userId
+            });
+            expect(scopeCheck).toBeTruthy();
+            userId = 2;
+            scopeCheck = await hasScopeOverUser({
+                oauthClientId,
+                userId
+            });
+            expect(scopeCheck).toBeFalsy();
+        });
+        it('should check if the User has scope only if the userId matches ', async () => {
+            const SequelizeMock = require('sequelize-mock');
+            const DBConnectionMock = new SequelizeMock();
+            const userClientMock = DBConnectionMock.define(
+                'oauth_clients',
+                userClient
+            );
+            await resetAndMockDB(db => {
+                db.oauth_clients = userClientMock;
+            });
+            const userId = 1;
+            let oauthClientId = userClient.id;
+            const { hasScopeOverUser } = require('utils');
+            let scopeCheck = await hasScopeOverUser({ oauthClientId, userId });
+            expect(scopeCheck).toBeTruthy();
+            oauthClientId = 2;
+            await resetAndMockDB(() => {}, {
+                scope: SCOPE_TYPE.USER,
+                resourceType: USER_ID
+            });
+            scopeCheck = await hasScopeOverUser({ oauthClientId, userId });
+            expect(scopeCheck).toBeFalsy();
+        });
+    });
+
+    describe('validateResources', () => {
+        it('should check if the resource type and id matches for the metadata', () => {
+            const { validateResources } = require('utils');
+            let metadata = get(adminToken, 'metadata');
+            let resourcesValidated = validateResources(
+                metadata,
+                OAUTH_CLIENT_ID,
+                1
+            );
+            expect(resourcesValidated).toBeTruthy();
+            const userToken = createMockTokenWithScope(
+                SCOPE_TYPE.USER,
+                USER_ID
+            );
+            metadata = get(userToken, 'metadata');
+            resourcesValidated = validateResources(metadata, USER_ID, 1);
+            expect(resourcesValidated).toBeTruthy();
+            resourcesValidated = validateResources(
+                metadata,
+                OAUTH_CLIENT_ID,
+                1
+            );
+            expect(resourcesValidated).toBeFalsy();
+        });
+    });
+});

--- a/tests/utils/validateScopeForRoute.test.js
+++ b/tests/utils/validateScopeForRoute.test.js
@@ -1,0 +1,94 @@
+import find from 'lodash/find';
+import { paths } from 'config/paths';
+import {
+    SCOPE_TYPE,
+    USER_ID,
+    GET_USER_PATH,
+    OAUTH_CLIENT_ID
+} from 'utils/constants';
+import { createMockTokenWithScope } from 'utils/mockData';
+import { resetAndMockDB } from 'utils/testUtils';
+import { findAccessToken } from 'daos/oauthAccessTokensDao';
+
+describe('validateScopeForRoute', () => {
+    const adminToken = createMockTokenWithScope(SCOPE_TYPE.ADMIN, USER_ID);
+    const userToken = createMockTokenWithScope(SCOPE_TYPE.USER, USER_ID);
+    const superAdminToken = createMockTokenWithScope(SCOPE_TYPE.SUPER_ADMIN);
+
+    const getUserPathConfig = find(paths, path => {
+        if (path.path === GET_USER_PATH) {
+            return path;
+        }
+    });
+
+    const request = {
+        route: {
+            path: getUserPathConfig.path,
+            method: getUserPathConfig.method
+        },
+        params: {
+            userId: 1
+        }
+    };
+
+    it('should validate SCOPE for a SUPER_ADMIN Client', async () => {
+        await resetAndMockDB(db => {}, {
+            scope: SCOPE_TYPE.SUPER_ADMIN,
+            resourceType: OAUTH_CLIENT_ID
+        });
+        const { validateScopeForRoute } = require('utils');
+        const superAdminCredentials = await findAccessToken(superAdminToken);
+        superAdminCredentials.oauthClientId = 1;
+        let isValid = false;
+        const payload = {
+            paths,
+            request,
+            credentials: superAdminCredentials
+        };
+        isValid = await validateScopeForRoute(payload);
+        expect(isValid).toBeTruthy();
+    });
+
+    it('should validate SCOPE for an ADMIN Client', async () => {
+        await resetAndMockDB(db => {}, {
+            scope: SCOPE_TYPE.ADMIN,
+            resourceType: USER_ID
+        });
+        const adminCredentials = await findAccessToken(adminToken);
+
+        const { validateScopeForRoute } = require('utils');
+        let isValid = false;
+        isValid = validateScopeForRoute({
+            paths,
+            request,
+            credentials: adminCredentials
+        });
+        expect(isValid).toBeTruthy();
+    });
+
+    it('should validate scope for a USER scope client', async () => {
+        await resetAndMockDB(() => {}, {
+            scope: SCOPE_TYPE.USER,
+            resourceType: OAUTH_CLIENT_ID
+        });
+        const userCredentials = await findAccessToken(userToken);
+        userCredentials.oauthClientId = 1;
+
+        const { validateScopeForRoute } = require('utils');
+        let isValid = false;
+        isValid = await validateScopeForRoute({
+            paths,
+            request,
+            credentials: userCredentials
+        });
+        expect(isValid).toBeTruthy();
+        userCredentials.oauthClientId = 2;
+        request.params.userId = 1;
+        isValid = await validateScopeForRoute({
+            paths,
+            request,
+            credentials: userCredentials
+        });
+        expect(isValid).toBeFalsy();
+    });
+});

--- a/utils/constants.js
+++ b/utils/constants.js
@@ -18,7 +18,11 @@ export const SCOPE_TYPE = {
     SUPER_ADMIN: 'SUPER_ADMIN',
     INTERNAL_SERVICE: 'INTERNAL_SERVICE'
 };
-export const ADMINS = [SCOPE_TYPE.SUPER_ADMIN, SCOPE_TYPE.ADMIN];
+export const ADMINS = [
+    SCOPE_TYPE.SUPER_ADMIN,
+    SCOPE_TYPE.ADMIN,
+    SCOPE_TYPE.INTERNAL_SERVICE
+];
 export const SLIDING_WINDOW = 1 * 24 * 60 * 60; // days * hours * minutes * seconds *
 export const INVALID_CLIENT_CREDENTIALS = 'Invalid client credentials';
 export const OAUTH_CLIENT_ID = 'OAUTH_CLIENT_ID';
@@ -31,3 +35,8 @@ export const SUPER_SCOPES = [
 export const GET_USER_PATH = '/users/{userId}';
 
 export const USER_ID = 'USER_ID';
+
+export const DEFAULT_METADATA_OPTIONS = {
+    scope: SCOPE_TYPE.ADMIN,
+    resourceType: OAUTH_CLIENT_ID
+};

--- a/utils/mockData.js
+++ b/utils/mockData.js
@@ -1,4 +1,9 @@
-import { GRANT_TYPE, SCOPE_TYPE, OAUTH_CLIENT_ID } from './constants';
+import {
+    GRANT_TYPE,
+    SCOPE_TYPE,
+    OAUTH_CLIENT_ID,
+    DEFAULT_METADATA_OPTIONS
+} from './constants';
 
 export const mockMetadata = (
     scope = SCOPE_TYPE.ADMIN,
@@ -28,24 +33,25 @@ export const mockData = {
         id: 1,
         firstName: 'Sharan',
         lastName: 'Salian',
-        email: 'sharan@wednesday.is'
+        email: 'sharan@wednesday.is',
+        oauth_client_id: 1
     },
-    MOCK_OAUTH_CLIENTS: {
+    MOCK_OAUTH_CLIENTS: (metadataOptions = DEFAULT_METADATA_OPTIONS) => ({
         id: 1,
         clientId: 'TEST_CLIENT_ID_1',
         clientSecret: 'TEST_CLIENT_SECRET',
         grantType: GRANT_TYPE.CLIENT_CREDENTIALS,
-        ...mockMetadata()
-    },
+        ...mockMetadata(metadataOptions.scope, metadataOptions.resourceType)
+    }),
     MOCK_OAUTH_CLIENT_TWO: {
-        id: 2,
+        id: 1,
         clientId: 'TEST_CLIENT_ID_2',
         clientSecret: 'TEST_CLIENT_SECRET',
         grantType: GRANT_TYPE.CLIENT_CREDENTIALS,
         ...mockMetadata(SCOPE_TYPE.USER)
     },
     MOCK_OAUTH_CLIENT_SUPER_USER: {
-        id: 2,
+        id: 1,
         clientId: 'TEST_CLIENT_ID_2',
         clientSecret: 'TEST_CLIENT_SECRET',
         grantType: GRANT_TYPE.CLIENT_CREDENTIALS,
@@ -72,13 +78,15 @@ export const mockData = {
     }
 };
 
-export const createMockTokenWithScope = scope => ({
+export const createMockTokenWithScope = (
+    scope,
+    resourceType = OAUTH_CLIENT_ID
+) => ({
     oauthClientId: 'TEST_CLIENT_ID_1',
     metadata: {
         scope: mockMetadata(scope).oauth_client_scope.get(),
-        resources: mockMetadata(
-            scope,
-            OAUTH_CLIENT_ID
-        ).oauth_client_resources[0].get()
+        resources: [
+            mockMetadata(scope, resourceType).oauth_client_resources[0].get()
+        ]
     }
 });

--- a/utils/testUtils.js
+++ b/utils/testUtils.js
@@ -1,8 +1,9 @@
 import { users } from 'models';
 import { init } from '../lib/testServer';
 import { mockData } from './mockData';
+import { DEFAULT_METADATA_OPTIONS } from './constants';
 
-export function configDB() {
+export function configDB(metadataOptions = DEFAULT_METADATA_OPTIONS) {
     const SequelizeMock = require('sequelize-mock');
     const DBConnectionMock = new SequelizeMock();
 
@@ -12,7 +13,7 @@ export function configDB() {
 
     const oauthClientsMock = DBConnectionMock.define(
         'oauth_clients',
-        mockData.MOCK_OAUTH_CLIENTS
+        mockData.MOCK_OAUTH_CLIENTS(metadataOptions)
     );
     oauthClientsMock.findOne = query => oauthClientsMock.findById(query);
 
@@ -47,9 +48,12 @@ export function bustDB() {
     users.sync({ force: true }); // this will clear all the entries in your table.
 }
 
-export async function mockDB(mockCallback = () => {}) {
+export async function mockDB(
+    mockCallback = () => {},
+    metadataOptions = DEFAULT_METADATA_OPTIONS
+) {
     jest.doMock('models', () => {
-        const sequelizeData = configDB();
+        const sequelizeData = configDB(metadataOptions);
         if (mockCallback) {
             mockCallback(sequelizeData);
         }
@@ -57,11 +61,14 @@ export async function mockDB(mockCallback = () => {}) {
     });
 }
 
-export const resetAndMockDB = async mockDBCallback => {
+export const resetAndMockDB = async (
+    mockDBCallback = () => {},
+    metadataOptions = DEFAULT_METADATA_OPTIONS
+) => {
     jest.clearAllMocks();
     jest.resetAllMocks();
     jest.resetModules();
-    mockDB(mockDBCallback);
+    mockDB(mockDBCallback, metadataOptions);
     const server = await init();
     return server;
 };


### PR DESCRIPTION
### Description

Added util tests
<img width="649" alt="Screenshot 2020-08-22 at 1 24 37 AM" src="https://user-images.githubusercontent.com/62387714/90929711-e32cd100-e416-11ea-96a1-c38df2c19803.png">

Added `metadataOptions` parameter in test utils, which can be used to set client metadata.
Updated changed `hasScopeOverUser` parameters to object -- VSCode indicated that async was useless for this function, changed it to take an object to remove this error (?)
Fixed path method for oauth2/clients/ changed to GET
Added validateScopeForRoutes unit tests

### GIf

![pr-util-tests-v1](https://user-images.githubusercontent.com/62387714/90930116-a2818780-e417-11ea-83f3-4209bd75ed29.gif)

Signed-off-by: Chris <christin@wednesday.is>